### PR TITLE
Fix storage helpers and stabilize search tool

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -117,6 +117,7 @@ npm 패키지 배포(npx 실행), Docker 이미지, CI/CD 자동화
 - **자동 백링크 관리**: 파일 변경 시 실시간 동기화
 - **원자적 파일 쓰기**: 데이터 손실 방지
 - **PARA 구조 관리**: 자동 카테고리 분류 및 아카이브
+- **MCP 검색 툴 안정화**: `createDefaultSearchEngine` 팩토리로 search_memory 툴 즉시 사용 가능
 
 ### 🚀 즉시 사용 가능한 기능
 ```bash

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -55,10 +55,17 @@ const validated = FrontMatterSchema.parse(frontMatter);
 - `parseMarkdownLinks()`: 마크다운 링크 파싱
 - `maskSensitiveInfo()`: 민감정보 마스킹
 - `createSnippet()`: 검색 스니펫 생성
+- `normalizePath()`: 플랫폼 독립 경로 정규화
+- `formatFileSize()`: 파일 크기 포맷팅
+- `createLogEntry()`: 구조화된 로그 엔트리 생성
 
 ### 에러 처리
 
 - `MemoryMcpError`: 기본 에러 클래스
 - `FileSystemError`: 파일 시스템 에러
 - `ValidationError`: 스키마 검증 에러
+- `ProtocolError`: MCP 프로토콜 에러
 - `IndexError`: 인덱스 관련 에러
+- `createErrorFromCode()`: 에러 코드 기반 에러 생성 헬퍼
+- `isMemoryMcpError()`: 에러 인스턴스 판별 유틸리티
+- `formatError()`: 로깅/표시용 문자열 포맷터

--- a/packages/index-search/src/fts-index.ts
+++ b/packages/index-search/src/fts-index.ts
@@ -189,29 +189,29 @@ export class FtsSearchEngine {
   private prepareSearchQuery(): Statement {
     return this.db.prepare(`
       SELECT
-        nf.uid,
-        nf.title,
-        nf.category,
-        nf.project,
-        nf.tags,
+        notes_fts.uid,
+        notes_fts.title,
+        notes_fts.category,
+        notes_fts.project,
+        notes_fts.tags,
         n.file_path,
-        bm25(nf) as score,
-        highlight(nf, 1, '<HIGHLIGHT>', '</HIGHLIGHT>') as title_highlight,
-        snippet(nf, 2, '<HIGHLIGHT>', '</HIGHLIGHT>', '...', ?) as content_snippet,
+        bm25(notes_fts) as score,
+        highlight(notes_fts, 1, '<HIGHLIGHT>', '</HIGHLIGHT>') as title_highlight,
+        snippet(notes_fts, 2, '<HIGHLIGHT>', '</HIGHLIGHT>', '...', ?) as content_snippet,
         COALESCE(GROUP_CONCAT(DISTINCT l.target_uid), '') as outgoing_links
-      FROM notes_fts nf
-      JOIN notes n ON nf.uid = n.uid
-      LEFT JOIN links l ON l.source_uid = nf.uid AND l.link_type = 'internal'
-      WHERE nf MATCH ?
-        AND (? IS NULL OR nf.category = ?)
-        AND (? IS NULL OR nf.project = ?)
+      FROM notes_fts
+      JOIN notes n ON notes_fts.uid = n.uid
+      LEFT JOIN links l ON l.source_uid = notes_fts.uid AND l.link_type = 'internal'
+      WHERE notes_fts MATCH ?
+        AND (? IS NULL OR notes_fts.category = ?)
+        AND (? IS NULL OR notes_fts.project = ?)
         AND (? = 0 OR EXISTS (
           SELECT 1 FROM (
             SELECT value FROM json_each('[' || ? || ']')
-          ) tags WHERE nf.tags LIKE '%' || tags.value || '%'
+          ) tags WHERE notes_fts.tags LIKE '%' || tags.value || '%'
         ))
-      GROUP BY nf.uid
-      ORDER BY bm25(nf)
+      GROUP BY notes_fts.uid
+      ORDER BY bm25(notes_fts)
       LIMIT ? OFFSET ?
     `);
   }
@@ -255,15 +255,15 @@ export class FtsSearchEngine {
    */
   private prepareCountQuery(): Statement {
     return this.db.prepare(`
-      SELECT COUNT(DISTINCT nf.uid) as count
-      FROM notes_fts nf
-      WHERE nf MATCH ?
-        AND (? IS NULL OR nf.category = ?)
-        AND (? IS NULL OR nf.project = ?)
+      SELECT COUNT(DISTINCT notes_fts.uid) as count
+      FROM notes_fts
+      WHERE notes_fts MATCH ?
+        AND (? IS NULL OR notes_fts.category = ?)
+        AND (? IS NULL OR notes_fts.project = ?)
         AND (? = 0 OR EXISTS (
           SELECT 1 FROM (
             SELECT value FROM json_each('[' || ? || ']')
-          ) tags WHERE nf.tags LIKE '%' || tags.value || '%'
+          ) tags WHERE notes_fts.tags LIKE '%' || tags.value || '%'
         ))
     `);
   }

--- a/packages/index-search/src/search-engine.ts
+++ b/packages/index-search/src/search-engine.ts
@@ -265,3 +265,18 @@ export class IndexSearchEngine {
       .digest('hex');
   }
 }
+
+export function createDefaultSearchEngine(
+  dbPath: string,
+  overrides: Partial<IndexConfig> = {}
+): IndexSearchEngine {
+  const config: IndexConfig = {
+    dbPath: normalizePath(dbPath),
+    walMode: true,
+    cacheSize: 1024,
+    pageSize: 4096,
+    ...overrides,
+  };
+
+  return new IndexSearchEngine(config);
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -47,7 +47,7 @@ const DEFAULT_OPTIONS: ResolvedServerOptions = {
  * MCP 서버 클래스
  * JSON-RPC 2.0 기반으로 stdin/stdout를 통해 통신
  */
-class MemoryMCPServer {
+export class MemoryMCPServer {
   private readonly server: Server;
   private readonly options: ResolvedServerOptions;
   private readonly toolContext: ToolExecutionContext;

--- a/packages/storage-md/README.md
+++ b/packages/storage-md/README.md
@@ -9,6 +9,7 @@ Markdown 파일 저장/로드와 Front Matter 처리를 위한 패키지입니�
 - **재시도 메커니즘**: 지수 백오프로 일시적 오류 처리
 - **경로 정규화**: OS 호환성 보장
 - **안전한 파일명**: 특수문자 자동 처리
+- **편의 API**: `safeRead`, `atomicWrite`, `getFileInfo`, `listMarkdownFiles`
 
 ### 👁️ **파일 감시 (VaultWatcher)**
 - **실시간 감지**: chokidar 기반 파일 변경 감지
@@ -67,6 +68,45 @@ const loadedNote = await loadNote('/vault/Projects/new-app.md');
 
 // UID로 노트 찾기
 const foundNote = await findNoteByUid('20250927T103000Z', '/vault');
+```
+
+### 파일 유틸리티
+
+```typescript
+import {
+  safeRead,
+  atomicWrite,
+  getFileInfo,
+  listMarkdownFiles,
+  validateFrontMatter
+} from '@memory-mcp/storage-md';
+
+// 안전하게 파일 읽기
+const contents = await safeRead('/vault/Projects/design.md');
+
+// 원자적으로 파일 쓰기
+await atomicWrite('/vault/Projects/design.md', '# 새 디자인 안건', {
+  createDirs: true
+});
+
+// 파일 메타데이터 확인
+const info = await getFileInfo('/vault/Projects/design.md');
+console.log(info.size, info.created, info.modified);
+
+// 마크다운 파일 목록 조회
+const files = await listMarkdownFiles('/vault', { recursive: true });
+files.forEach(file => console.log(file.path));
+
+// Front Matter 유효성 검사
+validateFrontMatter({
+  id: '20250927T103000123456Z',
+  title: '검증용 노트',
+  category: 'Resources',
+  tags: [],
+  created: new Date().toISOString(),
+  updated: new Date().toISOString(),
+  links: []
+});
 ```
 
 ### 파일 감시 설정


### PR DESCRIPTION
## Summary
- align the common error helpers with the expanded test coverage and document the new utilities
- harden Markdown storage parsing/writing, expose safe file helpers, and refresh package docs
- add an index-search factory and adjust FTS queries so the search_memory tool runs end-to-end

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7ada683348321add09eec48184763