### PR TITLE
refactor: streamline logging helpers

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -9,8 +9,8 @@ global.console = {
   ...console,
   // Uncomment to ignore console.log in tests
   // log: jest.fn(),
-  // debug: jest.fn(),
-  // info: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
   warn: jest.fn(),
   error: jest.fn(),
 };

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -8,15 +8,11 @@
 import { Command } from "commander";
 import { logger } from "@memory-mcp/common";
 import { startServer, type MemoryMcpServerOptions } from "./server.js";
+import { PACKAGE_VERSION } from "./version.js";
 import * as fs from "fs/promises";
 import * as path from "path";
 
 const program = new Command();
-
-/**
- * CLI 버전 정보
- */
-const PACKAGE_VERSION = "0.1.0";
 
 function parseInteger(value: string, defaultValue: number): number {
   const parsed = Number.parseInt(value, 10);


### PR DESCRIPTION
## Summary
- reuse the exported PACKAGE_VERSION constant in the CLI instead of maintaining a duplicate literal
- introduce a shared tool logging helper and reuse masked query data to remove repetitive log construction
- suppress debug and info console output during tests to avoid noisy Jest logs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7ea9c5ed48321bea667cfbc74445e