### PR TITLE
test: fix git snapshot child process mock

### DIFF
--- a/packages/storage-md/src/__tests__/git-snapshot.test.ts
+++ b/packages/storage-md/src/__tests__/git-snapshot.test.ts
@@ -8,12 +8,11 @@ import fs from 'fs/promises';
 import { GitSnapshotManager } from '../git-snapshot';
 import { FileWatchEventData, GitSnapshotResult } from '../types';
 
-// Mock child_process
-const mockExecFile = jest.fn();
-
 jest.mock('child_process', () => ({
-  execFile: mockExecFile,
+  execFile: jest.fn(),
 }));
+
+const mockExecFile = jest.requireMock('child_process').execFile as jest.Mock;
 
 jest.mock('util', () => ({
   promisify: jest.fn((fn) => fn),


### PR DESCRIPTION
## Summary
- ensure the git snapshot tests reuse the mocked `child_process.execFile` function returned by Jest so that it is initialized before use

## Testing
- npx jest packages/storage-md/src/__tests__/git-snapshot.test.ts --runTestsByPath *(fails: existing expectations around snapshot rollback and unique file handling still failing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e02f5e8483219deada5e8c386c6c