### PR TITLE
fix: improve git snapshot error handling

### DIFF
--- a/packages/storage-md/src/__tests__/git-snapshot.test.ts
+++ b/packages/storage-md/src/__tests__/git-snapshot.test.ts
@@ -8,12 +8,11 @@ import fs from 'fs/promises';
 import { GitSnapshotManager } from '../git-snapshot';
 import { FileWatchEventData, GitSnapshotResult } from '../types';
 
-// Mock child_process
-const mockExecFile = jest.fn();
-
 jest.mock('child_process', () => ({
-  execFile: mockExecFile,
+  execFile: jest.fn(),
 }));
+
+const mockExecFile = jest.requireMock('child_process').execFile as jest.Mock;
 
 jest.mock('util', () => ({
   promisify: jest.fn((fn) => fn),


### PR DESCRIPTION
## Summary
- ensure relative path resolution falls back to the configured repository path so unique file collection works before initialization
- surface original git command errors and avoid retrying commits to support predictable rollbacks

## Testing
- npm test -- --runTestsByPath packages/storage-md/src/__tests__/git-snapshot.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8e02f5e8483219deada5e8c386c6c