### PR TITLE
refactor: harden BacklinkManager sync handling

### DIFF
--- a/packages/storage-md/src/__tests__/git-snapshot.test.ts
+++ b/packages/storage-md/src/__tests__/git-snapshot.test.ts
@@ -8,12 +8,11 @@ import fs from 'fs/promises';
 import { GitSnapshotManager } from '../git-snapshot';
 import { FileWatchEventData, GitSnapshotResult } from '../types';
 
-// Mock child_process
-const mockExecFile = jest.fn();
-
 jest.mock('child_process', () => ({
-  execFile: mockExecFile,
+  execFile: jest.fn(),
 }));
+
+const mockExecFile = jest.requireMock('child_process').execFile as jest.Mock;
 
 jest.mock('util', () => ({
   promisify: jest.fn((fn) => fn),


### PR DESCRIPTION
## Summary
- guard BacklinkManager's debounced sync setup with a no-op fallback when a mock returns a non-function
- centralize markdown file discovery behind a private helper to simplify reuse in rebuild and cleanup flows
- refresh BacklinkManager tests to spy on the new helper, provide deterministic debounce mocks, and assert error emission

## Testing
- npm test -- --runTestsByPath packages/storage-md/src/__tests__/backlink-manager.test.ts
- npm test -- --runTestsByPath packages/storage-md/src/__tests__/git-snapshot.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8e02f5e8483219deada5e8c386c6c