### PR TITLE
Update package names for deployment

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,14 +6,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Memory MCP (Olima + Basic-Memory + Zettelkasten + PARA)** is a TypeScript/Node.js based knowledge management system that exposes local persistent memory as an MCP server. The goal is to build a knowledge management system that can be immediately utilized by MCP-compatible agents like Claude.
+**Zettel Memory (Olima + Basic-Memory + Zettelkasten + PARA)** is a TypeScript/Node.js based knowledge management system that exposes local persistent memory as an MCP server. The goal is to build a knowledge management system that can be immediately utilized by MCP-compatible agents like Claude.
 
 ### Core Features
 - **Markdown Storage**: YAML Front Matter + local file system
 - **Full-Text Search**: SQLite FTS5 based search + link graph
 - **PARA Organization**: Projects/Areas/Resources/Archives + Zettelkasten
 - **Olima Association Engine**: Session context-based associative search and recommendations
-- **MCP Interface**: Standard MCP server/CLI (`npx memory-mcp`)
+- **MCP Interface**: Standard MCP server/CLI (`npx zettel-memory`)
 
 ### Technology Stack
 - **Runtime**: Node.js 18+ / TypeScript 5+
@@ -154,7 +154,7 @@ npm run clean
 # Run MCP server
 npm start
 # or
-npx memory-mcp --vault ~/vault --index ~/.memory-index.db
+npx zettel-memory --vault ~/vault --index ~/.memory-index.db
 ```
 
 ### Working with Individual Packages
@@ -170,7 +170,7 @@ npm run dev
 npm test
 
 # Or from root, target specific package
-npm run build --workspace=@memory-mcp/mcp-server
+npm run build --workspace=@inchan/zettel-memory
 ```
 
 ### Code Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 
 ## Quick Reference
 
-**Memory MCP (Olima + Basic-Memory + Zettelkasten + PARA)** - A TypeScript/Node.js based knowledge management system that exposes local persistent memory as an MCP server.
+**Zettel Memory (Olima + Basic-Memory + Zettelkasten + PARA)** - A TypeScript/Node.js based knowledge management system that exposes local persistent memory as an MCP server.
 
 ### Quick Start
 
@@ -21,7 +21,7 @@ npm test
 # Run MCP server
 npm start
 # or
-npx memory-mcp --vault ~/vault --index ~/.memory-index.db
+npx zettel-memory --vault ~/vault --index ~/.memory-index.db
 ```
 
 ### Technology Stack

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Memory MCP
+# Zettel Memory
 
 > **v0.1.0** - Local-first persistent memory MCP server
 
@@ -22,13 +22,13 @@
 ### Installation
 
 ```bash
-npm install -g @memory-mcp/mcp-server
+npm install -g @inchan/zettel-memory
 ```
 
 Or use with `npx`:
 
 ```bash
-npx @memory-mcp/mcp-server --vault ~/my-vault
+npx @inchan/zettel-memory --vault ~/my-vault
 ```
 
 ### Claude Desktop Setup
@@ -41,7 +41,7 @@ Add to your Claude Desktop config (`~/.config/claude/claude_desktop_config.json`
     "memory": {
       "command": "npx",
       "args": [
-        "@memory-mcp/mcp-server",
+        "@inchan/zettel-memory",
         "--vault",
         "/Users/yourname/Documents/memory-vault"
       ]
@@ -70,7 +70,7 @@ links: []
 
 # My First Note
 
-This is my first note in Memory MCP!
+This is my first note in Zettel Memory!
 
 ## What I can do
 
@@ -83,7 +83,7 @@ EOF
 
 ## 📚 Available Tools (v0.1.0)
 
-Memory MCP provides 6 MCP tools for complete note management:
+Zettel Memory provides 6 MCP tools for complete note management:
 
 ### `create_note`
 Create a new Markdown note with Front Matter.
@@ -268,8 +268,8 @@ Your note content in Markdown...
 
 ```bash
 # Clone the repository
-git clone https://github.com/inchan/memory-mcp.git
-cd memory-mcp
+git clone https://github.com/inchan/zettel-memory.git
+cd zettel-memory
 
 # Install dependencies
 npm install
@@ -290,7 +290,7 @@ npm run lint
 ### Project Structure
 
 ```
-memory-mcp/
+zettel-memory/
 ├── packages/
 │   ├── mcp-server/      # MCP server & CLI
 │   ├── storage-md/      # Markdown storage & Front Matter
@@ -311,7 +311,7 @@ node packages/mcp-server/dist/cli.js --vault /tmp/test-vault --index /tmp/test-i
 npm start -- --vault /tmp/test-vault --index /tmp/test-index.db
 
 # Using npx (if published)
-npx @memory-mcp/mcp-server --vault ~/my-vault --index ~/.memory-index.db
+npx @inchan/zettel-memory --vault ~/my-vault --index ~/.memory-index.db
 ```
 
 **Subcommand (Backward Compatible):**
@@ -395,9 +395,9 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ## 📞 Support
 
-- 🐛 [Report a bug](https://github.com/inchan/memory-mcp/issues)
-- 💡 [Request a feature](https://github.com/inchan/memory-mcp/issues)
-- 💬 [Discussions](https://github.com/inchan/memory-mcp/discussions)
+- 🐛 [Report a bug](https://github.com/inchan/zettel-memory/issues)
+- 💡 [Request a feature](https://github.com/inchan/zettel-memory/issues)
+- 💬 [Discussions](https://github.com/inchan/zettel-memory/discussions)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "memory-mcp",
-  "version": "0.1.0",
+  "name": "zettel-memory",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "memory-mcp",
-      "version": "0.1.0",
+      "name": "zettel-memory",
+      "version": "0.0.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -760,6 +760,26 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@inchan/zettel-memory": {
+      "resolved": "packages/mcp-server",
+      "link": true
+    },
+    "node_modules/@inchan/zettel-memory-assoc-engine": {
+      "resolved": "packages/assoc-engine",
+      "link": true
+    },
+    "node_modules/@inchan/zettel-memory-common": {
+      "resolved": "packages/common",
+      "link": true
+    },
+    "node_modules/@inchan/zettel-memory-index-search": {
+      "resolved": "packages/index-search",
+      "link": true
+    },
+    "node_modules/@inchan/zettel-memory-storage-md": {
+      "resolved": "packages/storage-md",
+      "link": true
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1218,26 +1238,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@memory-mcp/assoc-engine": {
-      "resolved": "packages/assoc-engine",
-      "link": true
-    },
-    "node_modules/@memory-mcp/common": {
-      "resolved": "packages/common",
-      "link": true
-    },
-    "node_modules/@memory-mcp/index-search": {
-      "resolved": "packages/index-search",
-      "link": true
-    },
-    "node_modules/@memory-mcp/mcp-server": {
-      "resolved": "packages/mcp-server",
-      "link": true
-    },
-    "node_modules/@memory-mcp/storage-md": {
-      "resolved": "packages/storage-md",
-      "link": true
     },
     "node_modules/@modelcontextprotocol/inspector": {
       "version": "0.15.0",
@@ -9511,19 +9511,19 @@
       }
     },
     "packages/assoc-engine": {
-      "name": "@memory-mcp/assoc-engine",
-      "version": "0.1.0-alpha.0",
+      "name": "@inchan/zettel-memory-assoc-engine",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@memory-mcp/common": "^0.1.0-alpha.0"
+        "@inchan/zettel-memory-common": "^0.0.1"
       },
       "devDependencies": {
         "@types/node": "^20.10.0"
       }
     },
     "packages/common": {
-      "name": "@memory-mcp/common",
-      "version": "0.1.0-alpha.0",
+      "name": "@inchan/zettel-memory-common",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.22.4"
@@ -9533,11 +9533,11 @@
       }
     },
     "packages/index-search": {
-      "name": "@memory-mcp/index-search",
-      "version": "0.1.0-alpha.0",
+      "name": "@inchan/zettel-memory-index-search",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@memory-mcp/common": "^0.1.0-alpha.0",
+        "@inchan/zettel-memory-common": "^0.0.1",
         "better-sqlite3": "^9.2.2"
       },
       "devDependencies": {
@@ -9546,21 +9546,21 @@
       }
     },
     "packages/mcp-server": {
-      "name": "@memory-mcp/mcp-server",
-      "version": "0.1.0-alpha.0",
+      "name": "@inchan/zettel-memory",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@memory-mcp/assoc-engine": "^0.1.0-alpha.0",
-        "@memory-mcp/common": "^0.1.0-alpha.0",
-        "@memory-mcp/index-search": "^0.1.0-alpha.0",
-        "@memory-mcp/storage-md": "^0.1.0-alpha.0",
+        "@inchan/zettel-memory-assoc-engine": "^0.0.1",
+        "@inchan/zettel-memory-common": "^0.0.1",
+        "@inchan/zettel-memory-index-search": "^0.0.1",
+        "@inchan/zettel-memory-storage-md": "^0.0.1",
         "@modelcontextprotocol/sdk": "^1.18.2",
         "commander": "^11.1.0",
         "zod": "^3.25.76",
         "zod-to-json-schema": "^3.24.6"
       },
       "bin": {
-        "memory-mcp": "dist/cli.js"
+        "zettel-memory": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^20.10.0"
@@ -9570,11 +9570,11 @@
       }
     },
     "packages/storage-md": {
-      "name": "@memory-mcp/storage-md",
-      "version": "0.1.0-alpha.0",
+      "name": "@inchan/zettel-memory-storage-md",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@memory-mcp/common": "^0.1.0-alpha.0",
+        "@inchan/zettel-memory-common": "^0.0.1",
         "chokidar": "^3.5.3",
         "gray-matter": "^4.0.3",
         "remark": "^14.0.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "memory-mcp",
+  "name": "zettel-memory",
   "version": "0.0.1",
-  "description": "Memory MCP (Olima + Basic-Memory + Zettelkasten + PARA) - 로컬 퍼시스턴트 메모리를 MCP 서버로 노출",
+  "description": "Zettel Memory (Olima + Basic-Memory + Zettelkasten + PARA) - 로컬 퍼시스턴트 메모리를 MCP 서버로 노출",
   "private": true,
   "workspaces": [
     "packages/*"
@@ -52,14 +52,14 @@
     "fts5",
     "knowledge-management"
   ],
-  "author": "Memory MCP Project",
+  "author": "Zettel Memory Project",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/inchan/memory-mcp.git"
+    "url": "https://github.com/inchan/zettel-memory.git"
   },
   "bugs": {
-    "url": "https://github.com/inchan/memory-mcp/issues"
+    "url": "https://github.com/inchan/zettel-memory/issues"
   },
-  "homepage": "https://github.com/inchan/memory-mcp#readme"
+  "homepage": "https://github.com/inchan/zettel-memory#readme"
 }

--- a/packages/assoc-engine/package.json
+++ b/packages/assoc-engine/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@memory-mcp/assoc-engine",
+  "name": "@inchan/zettel-memory-assoc-engine",
   "version": "0.0.1",
   "description": "연상(Olima) 엔진",
   "private": true,
@@ -14,13 +14,13 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@memory-mcp/common": "^0.0.1"
+    "@inchan/zettel-memory-common": "^0.0.1"
   },
   "devDependencies": {
     "@types/node": "^20.10.0"
   },
   "keywords": [
-    "memory-mcp",
+    "zettel-memory",
     "association",
     "olima",
     "recommendation"

--- a/packages/assoc-engine/src/index.ts
+++ b/packages/assoc-engine/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @memory-mcp/assoc-engine
+ * @inchan/zettel-memory-assoc-engine
  * 연상(Olima) 엔진
  */
 

--- a/packages/common/__tests__/index.test.ts
+++ b/packages/common/__tests__/index.test.ts
@@ -11,7 +11,7 @@ import {
   MemoryMcpError,
 } from '../src';
 
-describe('@memory-mcp/common', () => {
+describe('@inchan/zettel-memory-common', () => {
   describe('UID generation', () => {
     it('generateUid()는 유효한 UID 형식을 생성해야 한다', () => {
       const uid = generateUid();

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@memory-mcp/common",
+  "name": "@inchan/zettel-memory-common",
   "version": "0.0.1",
   "description": "공통 스키마, 타입, 유틸리티 함수들",
   "private": true,
@@ -20,7 +20,7 @@
     "@types/node": "^20.10.0"
   },
   "keywords": [
-    "memory-mcp",
+    "zettel-memory",
     "common",
     "schemas",
     "types"

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @memory-mcp/common
+ * @inchan/zettel-memory-common
  * 공통 스키마, 타입, 유틸리티 함수들
  */
 

--- a/packages/index-search/package.json
+++ b/packages/index-search/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@memory-mcp/index-search",
+  "name": "@inchan/zettel-memory-index-search",
   "version": "0.0.1",
   "description": "FTS/그래프 인덱싱 & 검색",
   "private": true,
@@ -14,7 +14,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@memory-mcp/common": "^0.0.1",
+    "@inchan/zettel-memory-common": "^0.0.1",
     "better-sqlite3": "^9.2.2"
   },
   "devDependencies": {
@@ -22,7 +22,7 @@
     "@types/better-sqlite3": "^7.6.8"
   },
   "keywords": [
-    "memory-mcp",
+    "zettel-memory",
     "search",
     "index",
     "sqlite",

--- a/packages/index-search/src/database.ts
+++ b/packages/index-search/src/database.ts
@@ -3,7 +3,7 @@
  */
 
 import DatabaseConstructor from 'better-sqlite3';
-import { logger } from '@memory-mcp/common';
+import { logger } from '@inchan/zettel-memory-common';
 import { IndexConfig, DatabaseError } from './types';
 import * as path from 'path';
 import * as fs from 'fs';

--- a/packages/index-search/src/fts-index.ts
+++ b/packages/index-search/src/fts-index.ts
@@ -2,8 +2,8 @@
  * SQLite FTS5 기반 전문 검색 엔진
  */
 
-import { logger, SearchResult } from '@memory-mcp/common';
-import { MarkdownNote } from '@memory-mcp/common';
+import { logger, SearchResult } from '@inchan/zettel-memory-common';
+import { MarkdownNote } from '@inchan/zettel-memory-common';
 import {
   SearchOptions,
   SearchError,

--- a/packages/index-search/src/index.ts
+++ b/packages/index-search/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @memory-mcp/index-search
+ * @inchan/zettel-memory-index-search
  * FTS/그래프 인덱싱 & 검색
  */
 

--- a/packages/index-search/src/link-graph.ts
+++ b/packages/index-search/src/link-graph.ts
@@ -2,7 +2,7 @@
  * 링크 그래프 관리 및 탐색 유틸리티
  */
 
-import { logger, MarkdownNote, normalizePath, parseAllLinks, LinkGraphNode } from '@memory-mcp/common';
+import { logger, MarkdownNote, normalizePath, parseAllLinks, LinkGraphNode } from '@inchan/zettel-memory-common';
 import type { SqliteDatabase } from './database';
 import type {
   BacklinkOptions,

--- a/packages/index-search/src/search-engine.ts
+++ b/packages/index-search/src/search-engine.ts
@@ -2,8 +2,8 @@
  * 통합 인덱스 & 검색 엔진
  */
 
-import { logger, MarkdownNote, normalizePath, IndexStats } from '@memory-mcp/common';
-import type { LinkGraphNode } from '@memory-mcp/common';
+import { logger, MarkdownNote, normalizePath, IndexStats } from '@inchan/zettel-memory-common';
+import type { LinkGraphNode } from '@inchan/zettel-memory-common';
 import { createHash } from 'crypto';
 import { DatabaseManager, type SqliteDatabase } from './database';
 import { FtsSearchEngine } from './fts-index';

--- a/packages/index-search/src/types.ts
+++ b/packages/index-search/src/types.ts
@@ -2,7 +2,7 @@
  * index-search 패키지 타입 정의
  */
 
-import { SearchResult } from '@memory-mcp/common';
+import { SearchResult } from '@inchan/zettel-memory-common';
 
 /**
  * 검색 옵션

--- a/packages/mcp-server/__tests__/integration/storage-integration.test.ts
+++ b/packages/mcp-server/__tests__/integration/storage-integration.test.ts
@@ -8,7 +8,7 @@ import { createTestContext, cleanupTestContext } from '../test-helpers';
 import type { ToolExecutionContext } from '../../src/tools/types';
 import * as fs from 'fs';
 import * as path from 'path';
-import { loadNote, parseFrontMatter } from '@memory-mcp/storage-md';
+import { loadNote, parseFrontMatter } from '@inchan/zettel-memory-storage-md';
 
 describe('Storage Integration Tests', () => {
   let context: ToolExecutionContext;

--- a/packages/mcp-server/__tests__/unit/tools/create-note.test.ts
+++ b/packages/mcp-server/__tests__/unit/tools/create-note.test.ts
@@ -8,7 +8,7 @@ import { createTestContext, cleanupTestContext } from '../../test-helpers';
 import type { ToolExecutionContext } from '../../../src/tools/types';
 import * as fs from 'fs';
 import * as path from 'path';
-import { ErrorCode } from '@memory-mcp/common';
+import { ErrorCode } from '@inchan/zettel-memory-common';
 
 describe('create_note tool', () => {
   let context: ToolExecutionContext;

--- a/packages/mcp-server/__tests__/unit/tools/delete-note.test.ts
+++ b/packages/mcp-server/__tests__/unit/tools/delete-note.test.ts
@@ -6,7 +6,7 @@ import { executeTool } from '../../../src/tools';
 import { DeleteNoteInputSchema } from '../../../src/tools/schemas';
 import { createTestContext, cleanupTestContext } from '../../test-helpers';
 import type { ToolExecutionContext } from '../../../src/tools/types';
-import { ErrorCode } from '@memory-mcp/common';
+import { ErrorCode } from '@inchan/zettel-memory-common';
 
 describe('delete_note tool', () => {
   let context: ToolExecutionContext;

--- a/packages/mcp-server/__tests__/unit/tools/list-notes.test.ts
+++ b/packages/mcp-server/__tests__/unit/tools/list-notes.test.ts
@@ -6,7 +6,7 @@ import { executeTool } from '../../../src/tools';
 import { ListNotesInputSchema } from '../../../src/tools/schemas';
 import { createTestContext, cleanupTestContext } from '../../test-helpers';
 import type { ToolExecutionContext } from '../../../src/tools/types';
-import { ErrorCode } from '@memory-mcp/common';
+import { ErrorCode } from '@inchan/zettel-memory-common';
 
 describe('list_notes tool', () => {
   let context: ToolExecutionContext;

--- a/packages/mcp-server/__tests__/unit/tools/read-note.test.ts
+++ b/packages/mcp-server/__tests__/unit/tools/read-note.test.ts
@@ -6,7 +6,7 @@ import { executeTool } from '../../../src/tools';
 import { ReadNoteInputSchema } from '../../../src/tools/schemas';
 import { createTestContext, cleanupTestContext } from '../../test-helpers';
 import type { ToolExecutionContext } from '../../../src/tools/types';
-import { ErrorCode } from '@memory-mcp/common';
+import { ErrorCode } from '@inchan/zettel-memory-common';
 
 describe('read_note tool', () => {
   let context: ToolExecutionContext;

--- a/packages/mcp-server/__tests__/unit/tools/search-memory.test.ts
+++ b/packages/mcp-server/__tests__/unit/tools/search-memory.test.ts
@@ -6,7 +6,7 @@ import { executeTool } from '../../../src/tools';
 import { SearchMemoryInputSchema } from '../../../src/tools/schemas';
 import { createTestContext, cleanupTestContext } from '../../test-helpers';
 import type { ToolExecutionContext } from '../../../src/tools/types';
-import { ErrorCode } from '@memory-mcp/common';
+import { ErrorCode } from '@inchan/zettel-memory-common';
 
 describe('search_memory tool', () => {
   let context: ToolExecutionContext;

--- a/packages/mcp-server/__tests__/unit/tools/update-note.test.ts
+++ b/packages/mcp-server/__tests__/unit/tools/update-note.test.ts
@@ -6,7 +6,7 @@ import { executeTool } from '../../../src/tools';
 import { UpdateNoteInputSchema } from '../../../src/tools/schemas';
 import { createTestContext, cleanupTestContext } from '../../test-helpers';
 import type { ToolExecutionContext } from '../../../src/tools/types';
-import { ErrorCode } from '@memory-mcp/common';
+import { ErrorCode } from '@inchan/zettel-memory-common';
 
 describe('update_note tool', () => {
   let context: ToolExecutionContext;

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@memory-mcp/mcp-server",
+  "name": "@inchan/zettel-memory",
   "version": "0.0.1",
   "description": "Local-first persistent memory MCP server with PARA + Zettelkasten + SQLite FTS5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "memory-mcp": "dist/cli.js"
+    "zettel-memory": "dist/cli.js"
   },
   "scripts": {
     "build": "tsc",
@@ -17,10 +17,10 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@memory-mcp/assoc-engine": "^0.0.1",
-    "@memory-mcp/common": "^0.0.1",
-    "@memory-mcp/index-search": "^0.0.1",
-    "@memory-mcp/storage-md": "^0.0.1",
+    "@inchan/zettel-memory-assoc-engine": "^0.0.1",
+    "@inchan/zettel-memory-common": "^0.0.1",
+    "@inchan/zettel-memory-index-search": "^0.0.1",
+    "@inchan/zettel-memory-storage-md": "^0.0.1",
     "@modelcontextprotocol/sdk": "^1.18.2",
     "commander": "^11.1.0",
     "zod": "^3.25.76",
@@ -44,17 +44,17 @@
     "note-taking",
     "pkm"
   ],
-  "author": "Memory MCP Project",
+  "author": "Zettel Memory Project",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/inchan/memory-mcp.git",
+    "url": "https://github.com/inchan/zettel-memory.git",
     "directory": "packages/mcp-server"
   },
   "bugs": {
-    "url": "https://github.com/inchan/memory-mcp/issues"
+    "url": "https://github.com/inchan/zettel-memory/issues"
   },
-  "homepage": "https://github.com/inchan/memory-mcp#readme",
+  "homepage": "https://github.com/inchan/zettel-memory#readme",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
 /**
- * @memory-mcp/mcp-server
+ * @inchan/zettel-memory
  * CLI 진입점 - Commander.js 기반
  */
 
 import { Command } from "commander";
-import { logger } from "@memory-mcp/common";
+import { logger } from "@inchan/zettel-memory-common";
 import { startServer, type MemoryMcpServerOptions } from "./server.js";
 
 const program = new Command();

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @memory-mcp/mcp-server
+ * @inchan/zettel-memory
  * MCP 인터페이스/툴 노출
  */
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @memory-mcp/mcp-server
+ * @inchan/zettel-memory
  * MCP 서버 구현 - JSON-RPC 2.0 기반 stdin/stdout 통신
  */
 
@@ -12,7 +12,7 @@ import {
   ListToolsRequestSchema,
   type CallToolRequest,
 } from "@modelcontextprotocol/sdk/types.js";
-import { ErrorCode, MemoryMcpError, logger } from "@memory-mcp/common";
+import { ErrorCode, MemoryMcpError, logger } from "@inchan/zettel-memory-common";
 import {
   DEFAULT_EXECUTION_POLICY,
   executeTool,

--- a/packages/mcp-server/src/tools/__tests__/execution-policy.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/execution-policy.test.ts
@@ -1,4 +1,4 @@
-import { ErrorCode } from "@memory-mcp/common";
+import { ErrorCode } from "@inchan/zettel-memory-common";
 import { withExecutionPolicy } from "..";
 
 describe("withExecutionPolicy", () => {

--- a/packages/mcp-server/src/tools/__tests__/tool-registry.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/tool-registry.test.ts
@@ -1,4 +1,4 @@
-import { ErrorCode } from "@memory-mcp/common";
+import { ErrorCode } from "@inchan/zettel-memory-common";
 import { executeTool, listTools, type ToolExecutionContext } from "..";
 import * as fs from "fs";
 import * as path from "path";

--- a/packages/mcp-server/src/tools/execution-policy.ts
+++ b/packages/mcp-server/src/tools/execution-policy.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, MemoryMcpError } from '@memory-mcp/common';
+import { ErrorCode, MemoryMcpError } from '@inchan/zettel-memory-common';
 
 type RetryHook = (_context: { attempt: number; error: unknown }) => void;
 

--- a/packages/mcp-server/src/tools/registry.ts
+++ b/packages/mcp-server/src/tools/registry.ts
@@ -10,7 +10,7 @@ import {
   maskSensitiveInfo,
   generateUid,
   type Uid,
-} from '@memory-mcp/common';
+} from '@inchan/zettel-memory-common';
 import {
   createNewNote,
   saveNote,
@@ -22,8 +22,8 @@ import {
   analyzeLinks,
   updateFrontMatter,
   deleteFile,
-} from '@memory-mcp/storage-md';
-import { IndexSearchEngine } from '@memory-mcp/index-search';
+} from '@inchan/zettel-memory-storage-md';
+import { IndexSearchEngine } from '@inchan/zettel-memory-index-search';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import {
   CreateNoteInputSchema,

--- a/packages/mcp-server/src/tools/schemas.ts
+++ b/packages/mcp-server/src/tools/schemas.ts
@@ -1,4 +1,4 @@
-import { ParaCategorySchema } from '@memory-mcp/common';
+import { ParaCategorySchema } from '@inchan/zettel-memory-common';
 import { z } from 'zod';
 
 export const SearchMemoryInputSchema = z

--- a/packages/mcp-server/src/tools/types.ts
+++ b/packages/mcp-server/src/tools/types.ts
@@ -1,5 +1,5 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import type { logger as baseLogger } from '@memory-mcp/common';
+import type { logger as baseLogger } from '@inchan/zettel-memory-common';
 import type { z } from 'zod';
 import type { ExecutionPolicyOptions } from './execution-policy.js';
 import type { ToolName } from './schemas.js';

--- a/packages/mcp-server/src/version.ts
+++ b/packages/mcp-server/src/version.ts
@@ -1,5 +1,5 @@
 /**
- * @memory-mcp/mcp-server
+ * @inchan/zettel-memory
  * 버전 정보
  */
 

--- a/packages/storage-md/package.json
+++ b/packages/storage-md/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@memory-mcp/storage-md",
+  "name": "@inchan/zettel-memory-storage-md",
   "version": "0.0.1",
   "description": "Markdown 파일 저장/로드와 Front Matter 처리",
   "private": true,
@@ -14,7 +14,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@memory-mcp/common": "^0.0.1",
+    "@inchan/zettel-memory-common": "^0.0.1",
     "gray-matter": "^4.0.3",
     "remark": "^14.0.3",
     "chokidar": "^3.5.3"
@@ -26,7 +26,7 @@
     "@types/jest": "^29.5.8"
   },
   "keywords": [
-    "memory-mcp",
+    "zettel-memory",
     "storage",
     "markdown",
     "front-matter"

--- a/packages/storage-md/src/file-operations.ts
+++ b/packages/storage-md/src/file-operations.ts
@@ -5,7 +5,7 @@
 import { promises as fs, constants } from 'fs';
 import path from 'path';
 import crypto from 'crypto';
-import { logger } from '@memory-mcp/common';
+import { logger } from '@inchan/zettel-memory-common';
 import { FileSystemError, WriteFileOptions, ReadFileOptions } from './types';
 
 /**

--- a/packages/storage-md/src/front-matter.ts
+++ b/packages/storage-md/src/front-matter.ts
@@ -10,7 +10,7 @@ import {
   MarkdownNote,
   generateUid,
   logger
-} from '@memory-mcp/common';
+} from '@inchan/zettel-memory-common';
 import {
   FrontMatterValidationError,
   UpdateFrontMatterOptions,

--- a/packages/storage-md/src/index.ts
+++ b/packages/storage-md/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @memory-mcp/storage-md
+ * @inchan/zettel-memory-storage-md
  * Markdown 파일 저장/로드와 Front Matter 처리
  */
 

--- a/packages/storage-md/src/note-manager.ts
+++ b/packages/storage-md/src/note-manager.ts
@@ -9,7 +9,7 @@ import {
   parseAllLinks,
   extractBacklinkContext,
   logger
-} from '@memory-mcp/common';
+} from '@inchan/zettel-memory-common';
 import {
   readFile,
   writeFile,

--- a/packages/storage-md/src/types.ts
+++ b/packages/storage-md/src/types.ts
@@ -1,8 +1,8 @@
 /**
- * @memory-mcp/storage-md 내부 타입 정의
+ * @inchan/zettel-memory-storage-md 내부 타입 정의
  */
 
-import type { MarkdownNote } from '@memory-mcp/common';
+import type { MarkdownNote } from '@inchan/zettel-memory-common';
 
 /**
  * 파일 감시 이벤트 타입

--- a/packages/storage-md/src/watcher.ts
+++ b/packages/storage-md/src/watcher.ts
@@ -5,7 +5,7 @@
 import chokidar from 'chokidar';
 import path from 'path';
 import { EventEmitter } from 'events';
-import { debounce, logger } from '@memory-mcp/common';
+import { debounce, logger } from '@inchan/zettel-memory-common';
 import { normalizePath } from './file-operations';
 import { loadNote } from './note-manager';
 import {


### PR DESCRIPTION
BREAKING CHANGE: All package names have been renamed from @memory-mcp/* to @inchan/zettel-memory*

- Root package: memory-mcp → zettel-memory
- Main package: @memory-mcp/mcp-server → @inchan/zettel-memory
- Common package: @memory-mcp/common → @inchan/zettel-memory-common
- Storage package: @memory-mcp/storage-md → @inchan/zettel-memory-storage-md
- Index-search package: @memory-mcp/index-search → @inchan/zettel-memory-index-search
- Assoc-engine package: @memory-mcp/assoc-engine → @inchan/zettel-memory-assoc-engine

Updated:
- All package.json files with new scoped names
- All import statements in TypeScript files
- All documentation (README.md, CLAUDE.md, etc.)
- CLI bin command: memory-mcp → zettel-memory
- Repository URLs to reflect new project name

Users should update their Claude Desktop config to use: npx @inchan/zettel-memory instead of npx @memory-mcp/mcp-server