### PR TITLE
fix: resolve all ESLint errors and warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,9 @@ module.exports = {
     'prefer-const': 'error',
     'no-var': 'error',
     'no-undef': 'off',
-    'no-unused-vars': ['error', {
+    // Use TypeScript-aware version instead of base rule
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', {
       'argsIgnorePattern': '^_',
       'varsIgnorePattern': '^_',
       'ignoreRestSiblings': true

--- a/packages/common/src/__tests__/utils.test.ts
+++ b/packages/common/src/__tests__/utils.test.ts
@@ -205,21 +205,30 @@ describe('유틸리티 함수 테스트', () => {
     });
   });
 
+  // eslint-disable-next-line no-console -- Testing Logger requires console mocking
   describe('Logger', () => {
     let originalConsole: typeof console;
 
     beforeEach(() => {
       originalConsole = { ...console };
+      // eslint-disable-next-line no-console
       console.info = jest.fn();
+      // eslint-disable-next-line no-console
       console.error = jest.fn();
+      // eslint-disable-next-line no-console
       console.warn = jest.fn();
+      // eslint-disable-next-line no-console
       console.debug = jest.fn();
     });
 
     afterEach(() => {
+      // eslint-disable-next-line no-console
       console.info = originalConsole.info;
+      // eslint-disable-next-line no-console
       console.error = originalConsole.error;
+      // eslint-disable-next-line no-console
       console.warn = originalConsole.warn;
+      // eslint-disable-next-line no-console
       console.debug = originalConsole.debug;
       logger.setLevel('info'); // Reset to default
     });
@@ -229,6 +238,7 @@ describe('유틸리티 함수 테스트', () => {
       logger.info('Test info message');
 
       // MCP 호환성: 모든 로그는 stderr로 출력 (stdout은 JSON-RPC 전용)
+      // eslint-disable-next-line no-console
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('[INFO]')
       );
@@ -238,6 +248,7 @@ describe('유틸리티 함수 테스트', () => {
       logger.setLevel('info');
       logger.error('Test error message');
 
+      // eslint-disable-next-line no-console
       expect(console.error).toHaveBeenCalled();
     });
 
@@ -245,6 +256,7 @@ describe('유틸리티 함수 테스트', () => {
       logger.setLevel('warn');
       logger.warn('Test warning');
 
+      // eslint-disable-next-line no-console
       expect(console.warn).toHaveBeenCalled();
     });
 
@@ -253,6 +265,7 @@ describe('유틸리티 함수 테스트', () => {
       logger.debug('Debug message');
 
       // debug 레벨 이하이므로 출력되지 않음
+      // eslint-disable-next-line no-console
       expect(console.error).not.toHaveBeenCalledWith(
         expect.stringContaining('[DEBUG]'),
         expect.anything()
@@ -264,6 +277,7 @@ describe('유틸리티 함수 테스트', () => {
       logger.debug('Debug message');
 
       // MCP 호환성: 모든 로그는 stderr로 출력 (stdout은 JSON-RPC 전용)
+      // eslint-disable-next-line no-console
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('[DEBUG]')
       );
@@ -275,10 +289,12 @@ describe('유틸리티 함수 테스트', () => {
       logger.warn('Warn message');
 
       // error 레벨에서는 info와 warn이 필터링됨
+      // eslint-disable-next-line no-console
       expect(console.error).not.toHaveBeenCalledWith(
         expect.stringContaining('[INFO]'),
         expect.anything()
       );
+      // eslint-disable-next-line no-console
       expect(console.warn).not.toHaveBeenCalled();
     });
 
@@ -287,6 +303,7 @@ describe('유틸리티 함수 테스트', () => {
       logger.info('Message with metadata', { key: 'value' });
 
       // MCP 호환성: 모든 로그는 stderr로 출력 (stdout은 JSON-RPC 전용)
+      // eslint-disable-next-line no-console
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('[INFO]'),
         { key: 'value' }

--- a/packages/mcp-server/src/tools/index-recovery.ts
+++ b/packages/mcp-server/src/tools/index-recovery.ts
@@ -29,7 +29,9 @@ export class IndexRecoveryQueue {
   private workerInterval: NodeJS.Timeout | null = null;
 
   constructor(
-    private readonly getSearchEngine: (ctx: ToolExecutionContext) => IndexSearchEngine,
+    private readonly getSearchEngine: (
+      ctx: ToolExecutionContext
+    ) => IndexSearchEngine,
     private readonly context: ToolExecutionContext
   ) {}
 
@@ -94,7 +96,7 @@ export class IndexRecoveryQueue {
 
     try {
       const now = Date.now();
-      const entriesToProcess = this.queue.filter((entry) => {
+      const entriesToProcess = this.queue.filter(entry => {
         // 재시도 간격 계산 (exponential backoff)
         const delay = this.baseDelayMs * Math.pow(2, entry.retries);
         const nextRetryTime = entry.timestamp + delay;
@@ -165,12 +167,15 @@ export class IndexRecoveryQueue {
           reason: !isRetriable ? 'non-retriable error' : 'max retries exceeded',
         });
       } else {
-        this.context.logger.warn('[IndexRecoveryQueue] 작업 실패, 재시도 예정', {
-          operation: entry.operation,
-          noteUid: entry.noteUid,
-          retries: entry.retries,
-          nextRetryIn: `${this.baseDelayMs * Math.pow(2, entry.retries)}ms`,
-        });
+        this.context.logger.warn(
+          '[IndexRecoveryQueue] 작업 실패, 재시도 예정',
+          {
+            operation: entry.operation,
+            noteUid: entry.noteUid,
+            retries: entry.retries,
+            nextRetryIn: `${this.baseDelayMs * Math.pow(2, entry.retries)}ms`,
+          }
+        );
       }
     }
   }
@@ -208,7 +213,7 @@ export class IndexRecoveryQueue {
   private removeFromQueue(noteUid: string, operation: IndexOperation): void {
     const initialLength = this.queue.length;
     this.queue = this.queue.filter(
-      (e) => !(e.noteUid === noteUid && e.operation === operation)
+      e => !(e.noteUid === noteUid && e.operation === operation)
     );
 
     if (this.queue.length < initialLength) {
@@ -242,14 +247,17 @@ export class IndexRecoveryQueue {
     this.stopWorker();
 
     if (this.queue.length > 0) {
-      this.context.logger.warn('[IndexRecoveryQueue] 처리되지 않은 작업이 남아있음', {
-        remainingItems: this.queue.length,
-        items: this.queue.map(e => ({
-          operation: e.operation,
-          noteUid: e.noteUid,
-          retries: e.retries,
-        })),
-      });
+      this.context.logger.warn(
+        '[IndexRecoveryQueue] 처리되지 않은 작업이 남아있음',
+        {
+          remainingItems: this.queue.length,
+          items: this.queue.map(e => ({
+            operation: e.operation,
+            noteUid: e.noteUid,
+            retries: e.retries,
+          })),
+        }
+      );
     }
 
     this.queue = [];

--- a/packages/mcp-server/src/tools/metrics.ts
+++ b/packages/mcp-server/src/tools/metrics.ts
@@ -27,14 +27,17 @@ export interface MetricsSummary {
     totalRequests: number;
     successRate: number;
     avgDuration: number;
-    byTool: Record<string, {
-      count: number;
-      successCount: number;
-      failureCount: number;
-      avgDuration: number;
-      p50Duration: number;
-      p95Duration: number;
-    }>;
+    byTool: Record<
+      string,
+      {
+        count: number;
+        successCount: number;
+        failureCount: number;
+        avgDuration: number;
+        p50Duration: number;
+        p95Duration: number;
+      }
+    >;
   };
 
   // Index 복구 큐 메트릭
@@ -136,19 +139,26 @@ export class MetricsCollector {
    * 메트릭 요약 조회
    */
   getSummary(): MetricsSummary {
-    const completedMetrics = this.toolMetrics.filter(m => m.duration !== undefined);
+    const completedMetrics = this.toolMetrics.filter(
+      m => m.duration !== undefined
+    );
     const totalRequests = completedMetrics.length;
-    const successfulRequests = completedMetrics.filter(m => m.success === true).length;
+    const successfulRequests = completedMetrics.filter(
+      m => m.success === true
+    ).length;
 
     // Tool별 통계 계산
-    const byTool: Record<string, {
-      count: number;
-      successCount: number;
-      failureCount: number;
-      avgDuration: number;
-      p50Duration: number;
-      p95Duration: number;
-    }> = {};
+    const byTool: Record<
+      string,
+      {
+        count: number;
+        successCount: number;
+        failureCount: number;
+        avgDuration: number;
+        p50Duration: number;
+        p95Duration: number;
+      }
+    > = {};
 
     const toolNames = [...new Set(completedMetrics.map(m => m.toolName))];
 
@@ -168,15 +178,25 @@ export class MetricsCollector {
     }
 
     // Index 큐 통계
-    const latestQueueMetric = this.indexQueueMetrics[this.indexQueueMetrics.length - 1];
-    const totalSuccess = this.indexQueueMetrics.reduce((sum, m) => sum + m.successCount, 0);
-    const totalFailures = this.indexQueueMetrics.reduce((sum, m) => sum + m.failureCount, 0);
+    const latestQueueMetric =
+      this.indexQueueMetrics[this.indexQueueMetrics.length - 1];
+    const totalSuccess = this.indexQueueMetrics.reduce(
+      (sum, m) => sum + m.successCount,
+      0
+    );
+    const totalFailures = this.indexQueueMetrics.reduce(
+      (sum, m) => sum + m.failureCount,
+      0
+    );
 
     return {
       tools: {
         totalRequests,
-        successRate: totalRequests > 0 ? (successfulRequests / totalRequests) * 100 : 100,
-        avgDuration: completedMetrics.reduce((sum, m) => sum + (m.duration || 0), 0) / totalRequests || 0,
+        successRate:
+          totalRequests > 0 ? (successfulRequests / totalRequests) * 100 : 100,
+        avgDuration:
+          completedMetrics.reduce((sum, m) => sum + (m.duration || 0), 0) /
+            totalRequests || 0,
         byTool,
       },
       indexQueue: {
@@ -210,32 +230,54 @@ export class MetricsCollector {
     lines.push('# TYPE mcp_tool_requests_total counter');
     lines.push(`mcp_tool_requests_total ${summary.tools.totalRequests}`);
 
-    lines.push('# HELP mcp_tool_success_rate Success rate of tool requests (0-100)');
+    lines.push(
+      '# HELP mcp_tool_success_rate Success rate of tool requests (0-100)'
+    );
     lines.push('# TYPE mcp_tool_success_rate gauge');
     lines.push(`mcp_tool_success_rate ${summary.tools.successRate.toFixed(2)}`);
 
-    lines.push('# HELP mcp_tool_duration_avg_ms Average tool execution duration in milliseconds');
+    lines.push(
+      '# HELP mcp_tool_duration_avg_ms Average tool execution duration in milliseconds'
+    );
     lines.push('# TYPE mcp_tool_duration_avg_ms gauge');
-    lines.push(`mcp_tool_duration_avg_ms ${summary.tools.avgDuration.toFixed(2)}`);
+    lines.push(
+      `mcp_tool_duration_avg_ms ${summary.tools.avgDuration.toFixed(2)}`
+    );
 
     // Tool별 메트릭
     for (const [toolName, stats] of Object.entries(summary.tools.byTool)) {
       lines.push(`mcp_tool_requests_total{tool="${toolName}"} ${stats.count}`);
-      lines.push(`mcp_tool_success_total{tool="${toolName}"} ${stats.successCount}`);
-      lines.push(`mcp_tool_failure_total{tool="${toolName}"} ${stats.failureCount}`);
-      lines.push(`mcp_tool_duration_avg_ms{tool="${toolName}"} ${stats.avgDuration.toFixed(2)}`);
-      lines.push(`mcp_tool_duration_p50_ms{tool="${toolName}"} ${stats.p50Duration.toFixed(2)}`);
-      lines.push(`mcp_tool_duration_p95_ms{tool="${toolName}"} ${stats.p95Duration.toFixed(2)}`);
+      lines.push(
+        `mcp_tool_success_total{tool="${toolName}"} ${stats.successCount}`
+      );
+      lines.push(
+        `mcp_tool_failure_total{tool="${toolName}"} ${stats.failureCount}`
+      );
+      lines.push(
+        `mcp_tool_duration_avg_ms{tool="${toolName}"} ${stats.avgDuration.toFixed(2)}`
+      );
+      lines.push(
+        `mcp_tool_duration_p50_ms{tool="${toolName}"} ${stats.p50Duration.toFixed(2)}`
+      );
+      lines.push(
+        `mcp_tool_duration_p95_ms{tool="${toolName}"} ${stats.p95Duration.toFixed(2)}`
+      );
     }
 
     // Index 큐 메트릭
-    lines.push('# HELP mcp_index_queue_size Current size of index recovery queue');
+    lines.push(
+      '# HELP mcp_index_queue_size Current size of index recovery queue'
+    );
     lines.push('# TYPE mcp_index_queue_size gauge');
     lines.push(`mcp_index_queue_size ${summary.indexQueue.currentSize}`);
 
-    lines.push('# HELP mcp_index_queue_processed_total Total index operations processed');
+    lines.push(
+      '# HELP mcp_index_queue_processed_total Total index operations processed'
+    );
     lines.push('# TYPE mcp_index_queue_processed_total counter');
-    lines.push(`mcp_index_queue_processed_total ${summary.indexQueue.totalProcessed}`);
+    lines.push(
+      `mcp_index_queue_processed_total ${summary.indexQueue.totalProcessed}`
+    );
 
     lines.push('# HELP mcp_uptime_ms Server uptime in milliseconds');
     lines.push('# TYPE mcp_uptime_ms counter');

--- a/packages/mcp-server/src/tools/schemas.ts
+++ b/packages/mcp-server/src/tools/schemas.ts
@@ -193,13 +193,7 @@ export const GetBacklinksInputSchema = z
         required_error: 'UID는 필수 입력값입니다.',
       })
       .min(1, 'UID는 최소 1자 이상이어야 합니다.'),
-    limit: z
-      .number()
-      .int()
-      .min(1)
-      .max(100)
-      .default(20)
-      .optional(),
+    limit: z.number().int().min(1).max(100).default(20).optional(),
   })
   .strict();
 
@@ -213,11 +207,7 @@ export const GetMetricsInputSchema = z
       .default('json')
       .optional()
       .describe('출력 형식'),
-    reset: z
-      .boolean()
-      .default(false)
-      .optional()
-      .describe('메트릭 초기화 여부'),
+    reset: z.boolean().default(false).optional().describe('메트릭 초기화 여부'),
   })
   .strict();
 


### PR DESCRIPTION
Summary
ESLint 설정을 TypeScript 호환 규칙으로 업데이트하여 constructor parameter properties 인식 문제 해결
Prettier 포맷팅 에러 145개 수정 (index-recovery.ts, metrics.ts, registry.ts, schemas.ts)
Logger 테스트의 console 경고 16개 억제 (의도적인 console 모킹)
Changes
.eslintrc.js: no-unused-vars → @typescript-eslint/no-unused-vars 변경
packages/mcp-server/src/tools/*.ts: Prettier 포맷팅 적용
packages/common/src/__tests__/utils.test.ts: eslint-disable 주석 추가
Test plan

[object Object] - 에러 0개, 경고 0개

[object Object] - 빌드 성공

[object Object] - 타입체크 통과

[object Object] - 408개 테스트 전체 통과
